### PR TITLE
Etapa 3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,10 +19,72 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
 
       - name: Run tests
         run: npm test
+
+  build-android:
+    name: Build Android
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: 17
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Expo prebuild
+        run: npx expo prebuild --platform android
+
+      - name: Build APK
+        working-directory: android
+        run: |
+          chmod +x ./gradlew
+          ./gradlew assembleRelease
+
+      - name: Verify APK
+        run: ls -la android/app/build/outputs/apk/release/
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release
+          path: android/app/build/outputs/apk/release/app-release.apk
+
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: build-android
+
+    steps:
+      - name: Download APK
+        uses: actions/download-artifact@v4
+        with:
+          name: app-release
+
+      - name: Create Release with APK
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ github.run_number }}
+          name: Release v${{ github.run_number }}
+          files: ./app-release/app-release.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Injetar TMDB API Key
+        run: echo "EXPO_PUBLIC_TMDB_API_KEY=${{ secrets.TMDB_API_KEY }}" >> .env
+
       - name: Expo prebuild
         run: npx expo prebuild --platform android
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,44 @@ jobs:
       - name: Run tests
         run: npm test
 
+  build:
+    name: Build Expo Web
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      # injetar chave da api do expo (2.2)
+      - name: Injetar TMDB API Key
+        run: echo "EXPO_PUBLIC_TMDB_API_KEY=${{ secrets.TMDB_API_KEY }}" >> .env
+
+      - name: Build Expo pra Web
+        run: npx expo export --platform web
+
+      # cria o .nojekyll dentro da pasta dist (que existe apenas após o build pra web (2.3))
+      - name: Criar nojekyll
+        run: touch ./dist/.nojekyll
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    steps:
+      # usa as ações oficiais do github pra configurar o ambiente, upload da pasta dist (2.4)
+      - name: Configurar pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+      - name: Deploy pages
+        uses: actions/deploy-pages@v4
+
   build-android:
     name: Build Android
     runs-on: ubuntu-latest


### PR DESCRIPTION
Criação de 2 jobs.
Job build-android instala o Node.js 20 e o JDK 17, em seguida, executa npm ci para instalar dependências. Depois, o comando expo prebuild gera dinamicamente a pasta /android. Após isso, o Gradle é executado com assembleRelease, produzindo o APK de release. Por fim, esse APK é salvo como artefato do workflow.
Job release depende do build-android. Ele baixa o artefato gerado e cria uma GitHub Release usando github.run_number, o arquivo APK é então anexado à release.