### PR TITLE
Etapa Bônus versão: 3.0.0 (Integração com Docker Hub e Secrets)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,10 +62,20 @@ jobs:
       - name: Criar nojekyll
         run: touch ./dist/.nojekyll
 
-      - name: Build Docker Image
-        run: |
-          docker build -t tmdb-app:${{ steps.vars.outputs.sha_short }} .
-          docker tag tmdb-app:${{ steps.vars.outputs.sha_short }} tmdb-app:latest
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/tmdb-app:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/tmdb-app:${{ steps.vars.outputs.sha_short }}
 
       - name: Upload Dist
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Pedi ajuda para a IA pra realizar os testes antes de subir os commits, aparentemente está tudo certo com as etapas em si, mas notei que ao abrir o app no localhost, ele fica carregando a lista eternamente, testem na maquina de vcs depois de carregar o container.
Ps: Não é problema da etapa, a etapa pode ser aprovada e mergeada normalmente.

### Descrição do PR:
Implementada a automação da entrega contínua através da integração do pipeline com o Docker Hub. As principais mudanças incluem a configuração de autenticação segura via GitHub Secrets e o uso da action oficial para build e push automatizado. 

A imagem agora é publicada no repositório público com dupla tagueagem: uma tag dinâmica baseada no SHA curto do commit para rastreabilidade total e a tag "latest" para a versão estável mais recente.

#### 📦 Como utilizar a imagem (Docker Hub) (Escrito pelo Gemini):

Para validar ou rodar o projeto localmente via Docker, basta utilizar o repositório público **lyppe1201/tmdb-app**.

1. **Baixar a versão mais recente:**
   ```bash
   docker pull lyppe1201/tmdb-app:latest
   ```

2. **Executar o container:**
   ```bash
   docker run -d -p 8080:80 --name tmdb-app lyppe1201/tmdb-app:latest
   ```
   *Após rodar, a aplicação estará disponível em `localhost:8080`.*

3. **Rastreabilidade:**
   Caso precise testar uma versão específica de um commit, substitua `latest` pelos 7 caracteres iniciais do SHA do commit correspondente.