### PR TITLE
Etapa bonus 5

### DIFF
--- a/github/workflows/main.yml
+++ b/github/workflows/main.yml
@@ -1,0 +1,175 @@
+name: CI Pipeline
+
+on:
+  push:
+    branches:
+      - release
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Run Tests (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        node-version: ['20', '24']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+  build:
+    name: Build Expo Web
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Injetar TMDB API Key
+        run: echo "EXPO_PUBLIC_TMDB_API_KEY=${{ secrets.TMDB_API_KEY }}" >> .env
+
+      - name: Build Expo Web
+        run: npx expo export --platform web --output-dir dist
+
+      - name: Criar nojekyll
+        run: touch ./dist/.nojekyll
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/tmdb-app:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Upload Dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: ./dist
+
+  deploy:
+    name: Deploy Pages
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/release'
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    steps:
+      - name: Carregar Dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: ./dist
+
+      - name: Configurar pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+      - name: Deploy pages
+        uses: actions/deploy-pages@v4
+
+  build-android:
+    name: Build Android
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: "npm"
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: 17
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Injetar TMDB API Key
+        run: echo "EXPO_PUBLIC_TMDB_API_KEY=${{ secrets.TMDB_API_KEY }}" >> .env
+
+      - name: Expo prebuild
+        run: npx expo prebuild --platform android
+
+      - name: Build APK
+        working-directory: android
+        run: |
+          chmod +x ./gradlew
+          ./gradlew assembleRelease
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release
+          path: android/app/build/outputs/apk/release/app-release.apk
+
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: build-android
+    if: github.ref == 'refs/heads/release'
+
+    steps:
+      - name: Download APK
+        uses: actions/download-artifact@v4
+        with:
+          name: app-release
+
+      - name: Create Release with APK
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ github.run_number }}
+          name: Release v${{ github.run_number }}
+          files: ./app-release.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/github/workflows/main.yml
+++ b/github/workflows/main.yml
@@ -1,10 +1,10 @@
 name: CI Pipeline
 
 on:
-  pull_request:
   push:
     branches:
       - release
+  workflow_dispatch:
 
 jobs:
   test:
@@ -31,35 +31,42 @@ jobs:
       - name: Run tests
         run: npm test
 
-  build-web:
+  build:
     name: Build Expo Web
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/release'
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
       - name: Setup Node.js 24
         uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: "npm"
+
       - name: Install dependencies
         run: npm ci
+
       - name: Injetar TMDB API Key
         run: echo "EXPO_PUBLIC_TMDB_API_KEY=${{ secrets.TMDB_API_KEY }}" >> .env
+
       - name: Build Expo Web
         run: npx expo export --platform web --output-dir dist
+
       - name: Criar nojekyll
         run: touch ./dist/.nojekyll
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v6
         with:
@@ -68,6 +75,7 @@ jobs:
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/tmdb-app:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
       - name: Upload Dist
         uses: actions/upload-artifact@v4
         with:
@@ -77,8 +85,8 @@ jobs:
   deploy:
     name: Deploy Pages
     runs-on: ubuntu-latest
-    needs: build-web
-    if: github.event_name == 'push' && github.ref == 'refs/heads/release'
+    needs: build
+    if: github.ref == 'refs/heads/release'
 
     permissions:
       contents: read
@@ -107,7 +115,6 @@ jobs:
     name: Build Android
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/release'
 
     steps:
       - name: Checkout code
@@ -150,7 +157,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     needs: build-android
-    if: github.event_name == 'push' && github.ref == 'refs/heads/release'
+    if: github.ref == 'refs/heads/release'
 
     steps:
       - name: Download APK

--- a/github/workflows/main.yml
+++ b/github/workflows/main.yml
@@ -1,10 +1,10 @@
 name: CI Pipeline
 
 on:
+  pull_request:
   push:
     branches:
       - release
-  workflow_dispatch:
 
 jobs:
   test:
@@ -31,42 +31,35 @@ jobs:
       - name: Run tests
         run: npm test
 
-  build:
+  build-web:
     name: Build Expo Web
     runs-on: ubuntu-latest
     needs: test
-
+    if: github.event_name == 'push' && github.ref == 'refs/heads/release'
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
       - name: Setup Node.js 24
         uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: "npm"
-
       - name: Install dependencies
         run: npm ci
-
       - name: Injetar TMDB API Key
         run: echo "EXPO_PUBLIC_TMDB_API_KEY=${{ secrets.TMDB_API_KEY }}" >> .env
-
       - name: Build Expo Web
         run: npx expo export --platform web --output-dir dist
-
       - name: Criar nojekyll
         run: touch ./dist/.nojekyll
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v6
         with:
@@ -75,7 +68,6 @@ jobs:
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/tmdb-app:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
       - name: Upload Dist
         uses: actions/upload-artifact@v4
         with:
@@ -85,8 +77,8 @@ jobs:
   deploy:
     name: Deploy Pages
     runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == 'refs/heads/release'
+    needs: build-web
+    if: github.event_name == 'push' && github.ref == 'refs/heads/release'
 
     permissions:
       contents: read
@@ -115,6 +107,7 @@ jobs:
     name: Build Android
     runs-on: ubuntu-latest
     needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/release'
 
     steps:
       - name: Checkout code
@@ -157,7 +150,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     needs: build-android
-    if: github.ref == 'refs/heads/release'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/release'
 
     steps:
       - name: Download APK


### PR DESCRIPTION
adicionando fluxo de CI/CD. Testes rodam sempre, em qualquer situação de pull request, enquanto jobs de: build-web, deploy, build-android, release rodam apenas em push na release.
Troquei o nome do job build pra build-web também