### PR TITLE
Múltiplas Arquiteturas (Buildx)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,10 @@ jobs:
   test:
     name: Run Tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
-        node-version: ['20', '24']
+        node-version: ["20", "24"]
 
     steps:
       - name: Checkout code
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: github.event_name == 'push' && github.ref == 'refs/heads/release'
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -46,28 +46,39 @@ jobs:
       - name: Setup Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: "24"
           cache: "npm"
+
       - name: Install dependencies
         run: npm ci
+
       - name: Injetar TMDB API Key
         run: echo "EXPO_PUBLIC_TMDB_API_KEY=${{ secrets.TMDB_API_KEY }}" >> .env
+
       - name: Build Expo Web
         run: npx expo export --platform web --output-dir dist
+
       - name: Criar nojekyll
         run: touch ./dist/.nojekyll
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
+
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/tmdb-app:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/tmdb-app:${{ steps.vars.outputs.sha_short }}
@@ -121,7 +132,7 @@ jobs:
       - name: Setup Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: "24"
           cache: "npm"
 
       - name: Setup Java 17
@@ -129,6 +140,16 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 17
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
 
       - name: Install dependencies
         run: npm ci
@@ -143,7 +164,7 @@ jobs:
         working-directory: android
         run: |
           chmod +x ./gradlew
-          ./gradlew assembleRelease
+          ./gradlew assembleRelease --no-daemon --parallel
 
       - name: Upload APK
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Foi configurado o uso do Docker Buildx junto com o QEMU para permitir a construção de imagens Docker compatíveis com múltiplas arquiteturas. No step de build, foi adicionada a propriedade platforms com os valores linux/amd64 e linux/arm64, fazendo com que o pipeline gere uma única imagem “universal” capaz de rodar tanto em ambientes x86 (servidores tradicionais) quanto em ARM (como Raspberry Pi ou instâncias modernas de cloud).
Também adicionei cache para o Gradlew para verificar se o build do APK fica mais rápido.